### PR TITLE
Add HAS_SWIG_PYTHON_STRICT_BYTE_CHAR variable.

### DIFF
--- a/newsfragments/10.feature
+++ b/newsfragments/10.feature
@@ -1,0 +1,2 @@
+Add ``pycbf.HAS_SWIG_PYTHON_STRICT_BYTE_CHAR```, to tell if the module has been build with the ``SWIG_PYTHON_STRICT_BYTE_CHAR`` compile definition
+

--- a/newsfragments/8.feature
+++ b/newsfragments/8.feature
@@ -1,1 +1,0 @@
-Add ``pycbf.SWIG_PYTHON_STRICT_BYTE_CHAR```, to tell if the module has been build with that compile definition

--- a/pycbf_wrap.c
+++ b/pycbf_wrap.c
@@ -3234,6 +3234,11 @@ void get_error_message(){
     sprintf(error_message,"%s %s",error_message,"CBF_NOCOMPRESSION");
 }
 
+#ifdef SWIG_PYTHON_STRICT_BYTE_CHAR
+const bool HAS_SWIG_PYTHON_STRICT_BYTE_CHAR = true;
+#else
+const bool HAS_SWIG_PYTHON_STRICT_BYTE_CHAR = false;
+#endif
 
 
 
@@ -20409,16 +20414,16 @@ SWIGINTERN PyObject *cbf_handle_struct_swiginit(PyObject *SWIGUNUSEDPARM(self), 
   return SWIG_Python_InitShadowInstance(args);
 }
 
-SWIGINTERN int Swig_var_SWIG_PYTHON_STRICT_BYTE_CHAR_set(PyObject *_val SWIGUNUSED) {
-  SWIG_Error(SWIG_AttributeError,"Variable SWIG_PYTHON_STRICT_BYTE_CHAR is read-only.");
+SWIGINTERN int Swig_var_HAS_SWIG_PYTHON_STRICT_BYTE_CHAR_set(PyObject *_val SWIGUNUSED) {
+  SWIG_Error(SWIG_AttributeError,"Variable HAS_SWIG_PYTHON_STRICT_BYTE_CHAR is read-only.");
   return 1;
 }
 
 
-SWIGINTERN PyObject *Swig_var_SWIG_PYTHON_STRICT_BYTE_CHAR_get(void) {
+SWIGINTERN PyObject *Swig_var_HAS_SWIG_PYTHON_STRICT_BYTE_CHAR_get(void) {
   PyObject *pyobj = 0;
   
-  pyobj = SWIG_From_bool((bool)(SWIG_PYTHON_STRICT_BYTE_CHAR));
+  pyobj = SWIG_From_bool((bool)(HAS_SWIG_PYTHON_STRICT_BYTE_CHAR));
   return pyobj;
 }
 
@@ -29374,7 +29379,7 @@ SWIG_init(void) {
   }
   PyDict_SetItemString(md, "cvar", globals);
   Py_DECREF(globals);
-  SWIG_addvarlink(globals, "SWIG_PYTHON_STRICT_BYTE_CHAR", Swig_var_SWIG_PYTHON_STRICT_BYTE_CHAR_get, Swig_var_SWIG_PYTHON_STRICT_BYTE_CHAR_set);
+  SWIG_addvarlink(globals, "HAS_SWIG_PYTHON_STRICT_BYTE_CHAR", Swig_var_HAS_SWIG_PYTHON_STRICT_BYTE_CHAR_get, Swig_var_HAS_SWIG_PYTHON_STRICT_BYTE_CHAR_set);
 #if PY_VERSION_HEX >= 0x03000000
   return m;
 #else

--- a/src/pycbf/_wrapper.py
+++ b/src/pycbf/_wrapper.py
@@ -8984,5 +8984,5 @@ _pycbf.cbf_handle_struct_swigregister(cbf_handle_struct)
 
 
 cvar = _pycbf.cvar
-SWIG_PYTHON_STRICT_BYTE_CHAR = cvar.SWIG_PYTHON_STRICT_BYTE_CHAR
+HAS_SWIG_PYTHON_STRICT_BYTE_CHAR = cvar.HAS_SWIG_PYTHON_STRICT_BYTE_CHAR
 

--- a/src/pycbf/utils.py
+++ b/src/pycbf/utils.py
@@ -18,7 +18,7 @@ def cbf2str(string: Union[str, bytes]) -> str:
     if not isinstance(string, (str, bytes)):
         raise ValueError(f"Unrecognised pycbf string type: {type(string)}")
 
-    if pycbf.SWIG_PYTHON_STRICT_BYTE_CHAR:
+    if pycbf.HAS_SWIG_PYTHON_STRICT_BYTE_CHAR:
         if isinstance(string, bytes):
             return string.decode()
         return string

--- a/swig/pycbf.i
+++ b/swig/pycbf.i
@@ -320,6 +320,11 @@ void get_error_message(){
     sprintf(error_message,"%s %s",error_message,"CBF_NOCOMPRESSION");
 }
 
+#ifdef SWIG_PYTHON_STRICT_BYTE_CHAR
+const bool HAS_SWIG_PYTHON_STRICT_BYTE_CHAR = true;
+#else
+const bool HAS_SWIG_PYTHON_STRICT_BYTE_CHAR = false;
+#endif
 
 %} // End of code which is not wrapped but needed to compile
 
@@ -452,9 +457,5 @@ void get_error_message(){
 // cbfhandle object
 %include "cbfhandlewrappers.i"
 
-// Expose the SWIG_PYTHON_STRICT_BYTE_CHAR build variable as a global
-%#ifdef SWIG_PYTHON_STRICT_BYTE_CHAR
-const bool SWIG_PYTHON_STRICT_BYTE_CHAR = true;
-%#else
-const bool SWIG_PYTHON_STRICT_BYTE_CHAR = false;
-%#endif
+%immutable;
+extern bool HAS_SWIG_PYTHON_STRICT_BYTE_CHAR;

--- a/tests/test_3.py
+++ b/tests/test_3.py
@@ -1,30 +1,17 @@
 import pycbf
-
-if pycbf.SWIG_PYTHON_STRICT_BYTE_CHAR:
-    print("IS STRICT")
-
-    def pycbfstr(string: str) -> bytes:
-        """Shim to convert to representation of string natively handled by pycbf"""
-        return string.encode()
-
-
-else:
-
-    def pycbfstr(string: str) -> str:
-        """Shim to convert to representation of string natively handled by pycbf"""
-        return string
+from pycbf.utils import cbf2str
 
 
 def test_get_local_integer_byte_order():
-    assert pycbf.get_local_integer_byte_order() == pycbfstr("little_endian")
+    assert cbf2str(pycbf.get_local_integer_byte_order()) == "little_endian"
 
 
 def test_get_local_real_byte_order():
-    assert pycbf.get_local_real_byte_order() == pycbfstr("little_endian")
+    assert cbf2str(pycbf.get_local_real_byte_order()) == "little_endian"
 
 
 def test_get_local_real_format():
-    assert pycbf.get_local_real_format() == pycbfstr("ieee 754-1985")
+    assert cbf2str(pycbf.get_local_real_format()) == "ieee 754-1985"
 
 
 def test_compute_cell_volume():


### PR DESCRIPTION
Using plain SWIG_PYTHON_STRICT_BYTE_CHAR seemed to confuse SWIG.