### PR TITLE
Catch `PermissionError` when searching for dependencies (affects WSL)

### DIFF
--- a/regenerate_pycbf.py
+++ b/regenerate_pycbf.py
@@ -114,7 +114,7 @@ def check_tool(
         output = subprocess.check_output(
             [name] + version_args, stderr=subprocess.STDOUT, encoding="utf-8"
         )
-    except FileNotFoundError:
+    except (FileNotFoundError, PermissionError):
         print("FAIL")
         return False
     except subprocess.CalledProcessError:


### PR DESCRIPTION
I am half suspecting it may actually be better to catch _all_ exceptions, however ugly that is.